### PR TITLE
Rails 7 raw_filter method removed

### DIFF
--- a/lib/calib/devise/soft_deletion.rb
+++ b/lib/calib/devise/soft_deletion.rb
@@ -30,8 +30,8 @@ module Calib::Devise::SoftDeletion
       # https://gist.github.com/brenes/4503386
       self._validators.delete(:email)
       self._validate_callbacks.each do |callback|
-        if callback.raw_filter.respond_to? :attributes
-          callback.raw_filter.attributes.delete :email
+        if callback.filter.respond_to? :attributes
+          callback.filter.attributes.delete :email
         end
       end
 


### PR DESCRIPTION
Rails7にてraw_filterが削除されたので対応
https://github.com/zdennis/activerecord-import/issues/736